### PR TITLE
修复了renderShortcuts方法在没有图标时报undefined错的bug

### DIFF
--- a/js/win10.js
+++ b/js/win10.js
@@ -579,7 +579,8 @@ window.Win10 = {
         $("#win10-msg-nof").removeClass('on-new-msg fa-commenting-o');
     },
     renderShortcuts:function () {
-        var h=parseInt($("#win10 #win10-shortcuts")[0].offsetHeight/100);
+        var shortCutDOM=$("#win10 #win10-shortcuts")[0];
+        var h=shortCutDOM===undefined ? 0 : (shortCutDOM.offsetHeight / 100);
         var x=0,y=0;
         $("#win10 #win10-shortcuts .shortcut").each(function () {
             $(this).css({


### PR DESCRIPTION
在打算用vue3封装一下win10UI的组件时发现了这个bug，如果没有图标，$("#win10 #win10-shortcuts")[0]将为undefined，无法获取到offsetHeight导致报错，新增了一个判空逻辑。